### PR TITLE
Fixed `Past Events` filter, global search, and ui height difference.

### DIFF
--- a/src/components/sections/events/EventsBody.tsx
+++ b/src/components/sections/events/EventsBody.tsx
@@ -25,55 +25,49 @@ export default function EventsBody({ events = [] }: EventsBodyProps) {
   const [activeFilter, setActiveFilter] = useState<string>("upcoming");
   const [isSortActive, setIsSortActive] = useState(false);
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
+  const [searchTerm, setSearchTerm] = useState<string>(""); // Track search term
+  const [allSearchResults, setAllSearchResults] = useState<Event[]>(events); // Store all search results
 
-  // Initialize filtered events when component mounts or events change
-  useEffect(() => {
-    // Filter events based on the current active filter
-    const filtered = events.filter((event) => {
-      if (activeFilter === "past") {
+  // Apply both search and filter
+  const applyFilters = (searchResults: Event[], filterType: string) => {
+    return searchResults.filter((event) => {
+      if (filterType === "past") {
         return event.status === "past";
-      } else if (activeFilter === "upcoming") {
+      } else if (filterType === "upcoming") {
         return event.status === "upcoming";
       }
       return true; // Show all events for any other filter
     });
+  };
+
+  // Initialize filtered events when component mounts or events change
+  useEffect(() => {
+    // If there's a search term, use search results, otherwise use all events
+    const eventsToFilter = searchTerm ? allSearchResults : events;
+    const filtered = applyFilters(eventsToFilter, activeFilter);
 
     setFilteredEvents(filtered);
     setSortedEvents([]);
     setIsSortActive(false);
-  }, [events, activeFilter]);
+  }, [events, activeFilter, allSearchResults, searchTerm]);
 
   // Handle filter changes
   const handleFilterChange = (filter: string) => {
     setActiveFilter(filter);
-
-    // Filter events based on status
-    const filtered = events.filter((event) => {
-      if (filter === "past") {
-        return event.status === "past";
-      } else if (filter === "upcoming") {
-        return event.status === "upcoming";
-      }
-      return true; // Show all events for any other filter
-    });
-
-    setFilteredEvents(filtered);
-    // Reset sort when filter changes
-    setSortedEvents([]);
-    setIsSortActive(false);
+    // Don't reset search - let useEffect handle the filtering
   };
 
   // Handle search results
-  const handleSearchResults = (searchResults: Event[]) => {
-    // Further filter search results based on active filter
-    const filteredSearchResults = searchResults.filter((event) => {
-      if (activeFilter === "past") {
-        return event.status === "past";
-      } else if (activeFilter === "upcoming") {
-        return event.status === "upcoming";
-      }
-      return true; // Show all events for any other filter
-    });
+  const handleSearchResults = (
+    searchResults: Event[],
+    searchQuery?: string,
+  ) => {
+    // Store the search term and all search results
+    setSearchTerm(searchQuery || "");
+    setAllSearchResults(searchResults);
+
+    // Filter search results based on active filter
+    const filteredSearchResults = applyFilters(searchResults, activeFilter);
 
     setFilteredEvents(filteredSearchResults);
     // Reset sort when search changes

--- a/src/components/sections/events/EventsBody.tsx
+++ b/src/components/sections/events/EventsBody.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Box, Typography } from "@mui/material";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Event } from "@/constants/types/events.type";
 import { Poppins } from "next/font/google";
 import EventButton from "./common/buttons/EventButton";
@@ -20,22 +20,65 @@ interface EventsBodyProps {
 }
 
 export default function EventsBody({ events = [] }: EventsBodyProps) {
-  const [filteredEvents, setFilteredEvents] = useState<Event[]>(events);
+  const [filteredEvents, setFilteredEvents] = useState<Event[]>([]);
   const [sortedEvents, setSortedEvents] = useState<Event[]>(events);
   const [activeFilter, setActiveFilter] = useState<string>("upcoming");
   const [isSortActive, setIsSortActive] = useState(false);
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
 
+  // Initialize filtered events when component mounts or events change
+  useEffect(() => {
+    // Filter events based on the current active filter
+    const filtered = events.filter((event) => {
+      if (activeFilter === "past") {
+        return event.status === "past";
+      } else if (activeFilter === "upcoming") {
+        return event.status === "upcoming";
+      }
+      return true; // Show all events for any other filter
+    });
+
+    setFilteredEvents(filtered);
+    setSortedEvents([]);
+    setIsSortActive(false);
+  }, [events, activeFilter]);
+
   // Handle filter changes
   const handleFilterChange = (filter: string) => {
     setActiveFilter(filter);
-    // TODO: Implement actual filtering logic based on event status
-    // For now, we'll just update state
+
+    // Filter events based on status
+    const filtered = events.filter((event) => {
+      if (filter === "past") {
+        return event.status === "past";
+      } else if (filter === "upcoming") {
+        return event.status === "upcoming";
+      }
+      return true; // Show all events for any other filter
+    });
+
+    setFilteredEvents(filtered);
+    // Reset sort when filter changes
+    setSortedEvents([]);
+    setIsSortActive(false);
   };
 
   // Handle search results
   const handleSearchResults = (searchResults: Event[]) => {
-    setFilteredEvents(searchResults);
+    // Further filter search results based on active filter
+    const filteredSearchResults = searchResults.filter((event) => {
+      if (activeFilter === "past") {
+        return event.status === "past";
+      } else if (activeFilter === "upcoming") {
+        return event.status === "upcoming";
+      }
+      return true; // Show all events for any other filter
+    });
+
+    setFilteredEvents(filteredSearchResults);
+    // Reset sort when search changes
+    setSortedEvents([]);
+    setIsSortActive(false);
   };
 
   // Handle sort

--- a/src/components/sections/events/common/search/SearchBar.tsx
+++ b/src/components/sections/events/common/search/SearchBar.tsx
@@ -15,7 +15,7 @@ const poppins = Poppins({
 
 interface SearchBarProps {
   events: Event[];
-  onSearchResults: (filteredEvents: Event[]) => void;
+  onSearchResults: (filteredEvents: Event[], searchTerm?: string) => void;
   placeholder?: string;
   width?: number;
   height?: number;
@@ -59,7 +59,7 @@ export default function SearchBar({
     (value: string) => {
       setSearchTerm(value);
       const filteredEvents = searchEvents(events, value);
-      onSearchResults(filteredEvents);
+      onSearchResults(filteredEvents, value);
     },
     [events, onSearchResults],
   );

--- a/src/components/sections/events/event-carousel-v2/EventCarouselV2.tsx
+++ b/src/components/sections/events/event-carousel-v2/EventCarouselV2.tsx
@@ -107,7 +107,7 @@ export default function EventCarouselV2({
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        gap: "20px",
+        height: containerHeight + 40, // Reserve space for page indicators
         ...sx,
       }}
     >
@@ -197,17 +197,19 @@ export default function EventCarouselV2({
         </Box>
       </Box>
 
-      {/* Page Indicator Dots - Below the carousel */}
-      {totalPages > 1 && (
-        <Box
-          sx={{
-            display: "flex",
-            gap: 1,
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
-          {Array.from({ length: totalPages }).map((_, index) => (
+      {/* Page Indicator Dots - Fixed position with reserved space */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          height: "32px", // Fixed height for page indicators area
+          marginTop: "20px",
+        }}
+      >
+        {totalPages > 1 &&
+          Array.from({ length: totalPages }).map((_, index) => (
             <Box
               key={index}
               onClick={() => setCurrentPage(index)}
@@ -230,8 +232,7 @@ export default function EventCarouselV2({
               }}
             />
           ))}
-        </Box>
-      )}
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
# Changes

- Added functionality to the `Past Events` button. 
- Refined the search button to be persistent across `past` and `upcoming` events states.
- Adjusted `past` and `upcoming` events card height difference caused by the pagination dots when there are not enough cards to display the pagination.